### PR TITLE
Fix code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "socket.io-client": "^4.6.0",
     "sqlite3": "^5.1.4",
     "uuid": "^11.0.0",
-    "web-vitals": "^4.0.0"
+    "web-vitals": "^4.0.0",
+    "express-rate-limit": "^7.4.1"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.3",

--- a/server.ts
+++ b/server.ts
@@ -8,6 +8,7 @@ import md5 from 'md5';
 import { v1 as uuidv1, v4 as uuidv4 } from 'uuid';
 import { rockClimberData } from './src/data/games/rock-climber/';
 import { egyptianTreasuresData } from './src/data/games/egyptian-treasures/contr';
+import rateLimit from 'express-rate-limit';
 
 // Interfaces
 interface User {
@@ -85,6 +86,12 @@ class GameServer {
       },
     });
 
+    const limiter = rateLimit({
+      windowMs: 15 * 60 * 1000, // 15 minutes
+      max: 100, // max 100 requests per windowMs
+    });
+
+    this.app.use(limiter);
     this.app.use(express.static(__dirname + '/public'));
     this.app.get('/', (req: Request, res: Response) => {
       res.sendFile(__dirname + '/public/index.html');


### PR DESCRIPTION
Fixes [https://github.com/realbrodiwhite/Royal_Games_Casino/security/code-scanning/2](https://github.com/realbrodiwhite/Royal_Games_Casino/security/code-scanning/2)

To fix the problem, we need to introduce rate limiting to the Express application to prevent abuse of the file system access. The best way to achieve this is by using the `express-rate-limit` package, which allows us to set a maximum number of requests that can be made within a specified time window.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `server.ts` file.
3. Set up a rate limiter with appropriate configuration (e.g., maximum of 100 requests per 15 minutes).
4. Apply the rate limiter to the Express application.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
